### PR TITLE
Atualização do Java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM persapiens/maven-oraclejdk:3.5.0-8u121
+FROM persapiens/maven-oraclejdk:3.5.0-8u131
 MAINTAINER Marcelo Fernandes <persapiens@gmail.com>
 
 # update and upgrade


### PR DESCRIPTION
Atualização da versão do jdk. 
/* Ainda falta gerar e armazenar no dockerhub/persapiens a imagem maven-oraclejdk:3.5.0-8u131 */